### PR TITLE
Typo: documentation is not plural

### DIFF
--- a/tmpl/navigation.tmpl
+++ b/tmpl/navigation.tmpl
@@ -5,7 +5,7 @@ var self = this;
     <h3 class="applicationName"><a href="index.html"><?js= env.conf.templates.applicationName ?></a></h3>
 
     <div class="search">
-        <input id="search" type="text" class="form-control input-sm" placeholder="Search Documentations">
+        <input id="search" type="text" class="form-control input-sm" placeholder="Search Documentation">
     </div>
     <ul class="list">
     <?js


### PR DESCRIPTION
see https://github.com/davidshimjs/jaguarjs-jsdoc/pull/50

----
Documentation can not be plural in English.